### PR TITLE
fix: Convert rate limit headers to string format for consistency

### DIFF
--- a/src/utils/set-rate-limit-headers.ts
+++ b/src/utils/set-rate-limit-headers.ts
@@ -5,6 +5,6 @@ export function setRateLimitHeaders(
 	limit: number,
 	remaining: number,
 ) {
-	res.setHeader('X-RateLimit-Limit', limit)
-	res.setHeader('X-RateLimit-Remaining', remaining)
+	res.setHeader('X-RateLimit-Limit', String(limit))
+	res.setHeader('X-RateLimit-Remaining', String(remaining))
 }


### PR DESCRIPTION
Updated the setRateLimitHeaders function to ensure that the 'X-RateLimit-Limit' and 'X-RateLimit-Remaining' headers are set as string values, improving compatibility and preventing potential issues with header interpretation.