### PR TITLE
chore: optimize bundle size

### DIFF
--- a/.changeset/optimize-bundle.md
+++ b/.changeset/optimize-bundle.md
@@ -1,0 +1,5 @@
+---
+"@perseidesjs/medusa-plugin-rate-limit": patch
+---
+
+Optimize bundle size by excluding test files and source maps from published package

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
 		"typecheck": "tsc -b --noEmit",
 		"lint": "biome lint --write",
 		"lint:check": "biome lint",
-		"prepublishOnly": "npm run build",
+		"prepublishOnly": "npm run build:publish",
 		"version": "changeset version",
-		"release": "yarn build && changeset publish"
+		"release": "yarn build:publish && changeset publish"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,9 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"sourceMap": false
 	},
 	"include": ["src"],
-	"exclude": ["dist", "build", "node_modules", "__tests__"]
+	"exclude": ["dist", "build", "node_modules", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- Exclude test files from published bundle
- Disable source maps in production build
- Use `build:publish` for `prepublishOnly` and `release`

**Bundle size:** 15.1 kB → 5.9 kB (61% reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)